### PR TITLE
Update to v1.8.0 and support more platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 env:
   global:
     - BINARYBUILDER_DOWNLOADS_CACHE=downloads
-    - BINARYBUILDER_AUTOMATIC_APPLE=false
+    - BINARYBUILDER_AUTOMATIC_APPLE=true
 sudo: required
 
 # Before anything else, get the latest versions of things

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -18,10 +18,43 @@ cd $WORKSPACE/srcdir/libvpx-1.8.0/
 sed -i 's/cp -p/cp/' build/make/Makefile
 mkdir libvpx-build
 cd libvpx-build
-CROSS=$target
-apk add diffutils
-apk add yasm
-../configure --prefix=$prefix --target=generic-gnu --enable-shared --disable-static
+apk add diffutils yasm
+
+export CONFIG_OPTS="--enable-shared --disable-static --as=yasm"
+export TARGET=generic-gnu
+if [[ "${target}" == i686-linux-* ]]; then
+    export CROSS=x86-linux-gcc
+elif [[ "${target}" == x86_64-linux-* ]]; then
+    export CROSS=x86_64-linux-gcc
+elif [[ "${target}" == arm-linux-* ]]; then
+    export CROSS=armv7-linux-gcc
+elif [[ "${target}" == powerpc64le-linux-* ]]; then
+    export CROSS=ppc64le-linux-gcc
+elif [[ "${target}" == x86_64-apple-* ]]; then
+    export CROSS=x86_64-darwin14-gcc
+    export CC=/opt/${target}/bin/${target}-gcc
+    export CXX=/opt/${target}/bin/${target}-g++
+    export LD=/opt/${target}/bin/${target}-ld
+    export TARGET=$CROSS
+elif [[ "${target}" == i686-w64-mingw32 ]]; then
+    export CROSS=x86-win32-gcc
+    export CONFIG_OPTS="--as=yasm"
+elif [[ "${target}" == x86_64-w64-mingw32 ]]; then
+    export CROSS=x86_64-win64-gcc
+    export CONFIG_OPTS="--as=yasm"
+elif [[ "${target}" == x86_64-unknown-* ]]; then
+    export CROSS=x86_64-unknown-gcc
+    export CC=/opt/${target}/bin/${target}-gcc
+    export CXX=/opt/${target}/bin/${target}-g++
+    export LD=/opt/${target}/bin/${target}-ld
+    export CONFIG_OPTS="--enable-shared --disable-static --as=yasm --disable-multithread"
+elif [[ "${target}" == aarch64-linux-* ]]; then
+    export CROSS=aarch64-linux-gcc
+else
+    export CROSS=$target
+fi
+
+../configure --prefix=$prefix --target=${TARGET} ${CONFIG_OPTS}
 echo "SRC_PATH_BARE=.." >> config.mk
 echo "target=libs" >> config.mk
 make -j${nproc}
@@ -41,7 +74,7 @@ platforms = [
     Linux(:aarch64, libc=:musl),
     Linux(:armv7l, libc=:musl, call_abi=:eabihf),
     # MacOS(:x86_64, compiler_abi=CompilerABI(:gcc4)),
-    # FreeBSD(:x86_64),
+    FreeBSD(:x86_64),
     Windows(:i686),
     Windows(:x86_64)
 ]

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -10,17 +10,19 @@ sources = [
     "https://github.com/webmproject/libvpx/archive/v1.8.0.tar.gz" =>
     "86df18c694e1c06cc8f83d2d816e9270747a0ce6abe316e93a4f4095689373f6",
 
+    "./patches"
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir/libvpx-1.8.0/
+cd $WORKSPACE/srcdir/libvpx-*/
 sed -i 's/cp -p/cp/' build/make/Makefile
+patch -p1 < $WORKSPACE/srcdir/macos.patch
 mkdir libvpx-build
 cd libvpx-build
 apk add diffutils yasm
 
-export CONFIG_OPTS="--enable-shared --disable-static --as=yasm"
+export CONFIG_OPTS="--enable-shared --disable-static"
 export TARGET=generic-gnu
 if [[ "${target}" == i686-linux-* ]]; then
     export CROSS=x86-linux-gcc
@@ -38,23 +40,25 @@ elif [[ "${target}" == x86_64-apple-* ]]; then
     export TARGET=$CROSS
 elif [[ "${target}" == i686-w64-mingw32 ]]; then
     export CROSS=x86-win32-gcc
-    export CONFIG_OPTS="--as=yasm"
+    export CONFIG_OPTS=""
+    export TARGET=$CROSS
 elif [[ "${target}" == x86_64-w64-mingw32 ]]; then
     export CROSS=x86_64-win64-gcc
-    export CONFIG_OPTS="--as=yasm"
+    export CONFIG_OPTS=""
+    export TARGET=$CROSS
 elif [[ "${target}" == x86_64-unknown-* ]]; then
     export CROSS=x86_64-unknown-gcc
     export CC=/opt/${target}/bin/${target}-gcc
     export CXX=/opt/${target}/bin/${target}-g++
     export LD=/opt/${target}/bin/${target}-ld
-    export CONFIG_OPTS="--enable-shared --disable-static --as=yasm --disable-multithread"
+    export CONFIG_OPTS="--enable-shared --disable-static --disable-multithread"
 elif [[ "${target}" == aarch64-linux-* ]]; then
     export CROSS=aarch64-linux-gcc
 else
     export CROSS=$target
 fi
 
-../configure --prefix=$prefix --target=${TARGET} ${CONFIG_OPTS}
+../configure --prefix=$prefix --target=${TARGET} --as=yasm ${CONFIG_OPTS}
 echo "SRC_PATH_BARE=.." >> config.mk
 echo "target=libs" >> config.mk
 make -j${nproc}
@@ -63,21 +67,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = [
-    Linux(:i686, libc=:glibc),
-    Linux(:x86_64, libc=:glibc),
-    Linux(:aarch64, libc=:glibc),
-    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
-    Linux(:powerpc64le, libc=:glibc),
-    Linux(:i686, libc=:musl),
-    Linux(:x86_64, libc=:musl),
-    Linux(:aarch64, libc=:musl),
-    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
-    # MacOS(:x86_64, compiler_abi=CompilerABI(:gcc4)),
-    FreeBSD(:x86_64),
-    Windows(:i686),
-    Windows(:x86_64)
-]
+platforms = supported_platforms()
 
 # The products that we will ensure are always built
 products(prefix) = [

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -3,35 +3,48 @@
 using BinaryBuilder
 
 name = "LibVPX"
-version = v"5.0.0"
+version = v"1.8.0"
 
 # Collection of sources required to build LibVPX
 sources = [
-    "https://github.com/webmproject/libvpx/archive/v1.7.0/libvpx-1.7.0.tar.gz" =>
-    "1fec931eb5c94279ad219a5b6e0202358e94a93a90cfb1603578c326abfc1238",
+    "https://github.com/webmproject/libvpx/archive/v1.8.0.tar.gz" =>
+    "86df18c694e1c06cc8f83d2d816e9270747a0ce6abe316e93a4f4095689373f6",
 
 ]
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd libvpx-1.7.0/
+cd $WORKSPACE/srcdir/libvpx-1.8.0/
 sed -i 's/cp -p/cp/' build/make/Makefile
 mkdir libvpx-build
 cd libvpx-build
 CROSS=$target
 apk add diffutils
+apk add yasm
 ../configure --prefix=$prefix --target=generic-gnu --enable-shared --disable-static
 echo "SRC_PATH_BARE=.." >> config.mk
 echo "target=libs" >> config.mk
 make -j${nproc}
 make install
-
 """
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = [
+    Linux(:i686, libc=:glibc),
+    Linux(:x86_64, libc=:glibc),
+    Linux(:aarch64, libc=:glibc),
+    Linux(:armv7l, libc=:glibc, call_abi=:eabihf),
+    Linux(:powerpc64le, libc=:glibc),
+    Linux(:i686, libc=:musl),
+    Linux(:x86_64, libc=:musl),
+    Linux(:aarch64, libc=:musl),
+    Linux(:armv7l, libc=:musl, call_abi=:eabihf),
+    # MacOS(:x86_64, compiler_abi=CompilerABI(:gcc4)),
+    # FreeBSD(:x86_64),
+    Windows(:i686),
+    Windows(:x86_64)
+]
 
 # The products that we will ensure are always built
 products(prefix) = [
@@ -40,9 +53,7 @@ products(prefix) = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "https://github.com/jpsamaroo/YasmBuilder/releases/download/v1.3.0-pre/build_YasmBuilder.v1.3.0.jl"
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
 build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
-

--- a/patches/macos.patch
+++ b/patches/macos.patch
@@ -1,0 +1,26 @@
+diff --git a/libs.mk b/libs.mk
+index d0c4d64..28633ce 100644
+--- a/libs.mk
++++ b/libs.mk
+
+@@ -145,7 +145,6 @@
+ endif
+ CODEC_EXPORTS-yes += vpx/exports_com
+ CODEC_EXPORTS-$(CONFIG_ENCODERS) += vpx/exports_enc
+-CODEC_EXPORTS-$(CONFIG_VP9_ENCODER) += vpx/exports_spatial_svc
+ CODEC_EXPORTS-$(CONFIG_DECODERS) += vpx/exports_dec
+ 
+ INSTALL-LIBS-yes += include/vpx/vpx_codec.h
+
+diff --git a/vpx/exports_spatial_svc b/vpx/exports_spatial_svc
+deleted file mode 100644
+index 9d60cb6..0000000
+--- a/vpx/exports_spatial_svc
++++ /dev/null
+
+@@ -1,5 +0,0 @@
+-text vpx_svc_dump_statistics
+-text vpx_svc_encode
+-text vpx_svc_init
+-text vpx_svc_release
+-text vpx_svc_set_options


### PR DESCRIPTION
Install yasm with apk, no need of the external dependency.

I couldn't make the two BSD systems work because they use Clang by default but libvpx doesn't like it.  I couldn't change the compiler within BinaryBuilder, I thought that setting the `compiler_abi` would have done the trick, but it didn't.

CC: @ianshmean